### PR TITLE
Don't automatically create namespaces if they don't exist

### DIFF
--- a/pkg/tunnel/authz.go
+++ b/pkg/tunnel/authz.go
@@ -281,21 +281,6 @@ func (p *authzProvisioner) provisionAuthz(ctx context.Context, auth *sentryrpc.G
 		return err
 	}
 
-	for _, namespace := range auth.Namespaces {
-		ns, _, err := runtime.ToUnstructuredObject(namespace)
-		if err != nil {
-			_log.Infow("unable to make namespace runtime object", "error", err)
-			return err
-		}
-
-		err = applier.Apply(ctx, ns)
-		// Ignore already exist error
-		if err != nil && !strings.Contains(err.Error(), "already exists") {
-			_log.Infow("unable to apply namespace", "error", err)
-			return err
-		}
-	}
-
 	for _, clusterRole := range auth.ClusterRoles {
 		cro, _, err := runtime.ToUnstructuredObject(clusterRole)
 		if err != nil {


### PR DESCRIPTION
### What does this PR change?

Stop automatically creating a new namespace if the user has access to one but is not available

The only caveat is that the new namespace takes about 5min to be
recognized once added to the cluster as we cache authz for that amount
of time.

https://github.com/paralus/relay/blob/d14b13dab7f9b3fbb6e698d2ed5ce47480436694/pkg/tunnel/authz.go#L404

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
