### PR TITLE
Drop GOPRIVATE from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ DEV_TAG := docker.io/${DEV_USER}/relay:$(TS)
 
 .PHONY: tidy
 tidy:
-	GOPRIVATE=github.com/paralus/* go mod tidy
+	go mod tidy
 
 .PHONY: vendor
 vendor:
-	GOPROXY=direct GOPRIVATE=github.com/paralus/* go mod vendor
+	GOPROXY=direct go mod vendor
 
 check:
 	go fmt ./...


### PR DESCRIPTION
### What does this PR change?

Drop use of GOPRIVATE from Makefile

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
