### PR TITLE
read authzexpiry duration from sa configured and run cleanup based on it

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func terminate(cancel context.CancelFunc) {
 	os.Exit(1)
 }
 
-//os signal handler
+// os signal handler
 func signalHandler(sig os.Signal, cancel context.CancelFunc) {
 	if sig == syscall.SIGINT || sig == syscall.SIGKILL || sig == syscall.SIGTERM || sig == syscall.SIGQUIT {
 		log.Error(

--- a/pkg/cleanup/authz.go
+++ b/pkg/cleanup/authz.go
@@ -21,13 +21,14 @@ var (
 
 const (
 	// how often should the cleanup routine run
-	sweepInterval = time.Minute * 10
+	sweepInterval = time.Minute * 5
 	// any authz which is olderThan this should be cleaned up
-	olderThan = time.Hour * 8
+	// olderThan = time.Hour * 8
 
 	paralusRelayLabel = "paralus-relay"
 	authzRefreshLabel = "authz-refreshed"
 	paralusSystemNS   = "paralus-system"
+	authzExpiryLabel  = "authz-expiry"
 
 	maxResults = 50
 )
@@ -42,9 +43,9 @@ func getMatchingLabelSelector() (sel client.MatchingLabelsSelector, err error) {
 	}
 
 	refreshLabelReq, err = labels.NewRequirement(
-		authzRefreshLabel,
+		authzExpiryLabel,
 		selection.LessThan,
-		[]string{strconv.FormatInt(time.Now().Add(-olderThan).Unix(), 10)},
+		[]string{strconv.FormatInt(time.Now().Unix(), 10)},
 	)
 	if err != nil {
 		_log.Infow("unable to create authz refresh requirment", "error", err)

--- a/pkg/proxy/kube_proxy.go
+++ b/pkg/proxy/kube_proxy.go
@@ -195,7 +195,7 @@ type unixHandlerOptions struct {
 	sni      string
 }
 
-//UnixKubeHandler unix handler
+// UnixKubeHandler unix handler
 func UnixKubeHandler(sockPath, key, username, sni string) (http.Handler, error) {
 
 	hkey := getRTCacheKey(username + key)
@@ -242,7 +242,7 @@ func peerDialContext(relayIP string) func(ctx context.Context, network, addr str
 	}
 }
 
-//makePeerUpgradeTransport ...
+// makePeerUpgradeTransport ...
 func makePeerUpgradeTransport(relayIP string, tlscfg *tls.Config) (k8proxy.UpgradeRequestRoundTripper, error) {
 	rt := utilnet.SetOldTransportDefaults(&http.Transport{
 		DialContext:         peerDialContext(relayIP),
@@ -263,7 +263,7 @@ func makePeerUpgradeTransport(relayIP string, tlscfg *tls.Config) (k8proxy.Upgra
 	return k8proxy.NewUpgradeRequestRoundTripper(rt, upgrader), nil
 }
 
-//PeerKubeHandler peer proxying handler
+// PeerKubeHandler peer proxying handler
 func PeerKubeHandler(tlscfg *tls.Config, relayIP string) (http.Handler, error) {
 	hkey := getRTCacheKey(tlscfg.ServerName)
 	if val, ok := relayPeerRoundTripper.Get(hkey); ok {

--- a/pkg/proxy/service_account.go
+++ b/pkg/proxy/service_account.go
@@ -125,7 +125,7 @@ func getServiceAccountSecret(ctx context.Context, c k8sclient.Client, name, name
 	return nil, fmt.Errorf("service account %s/%s does not have secrets of type ServiceAccountToken", namespace, name)
 }
 
-//DeleteServiceAccount from cluster and cache
+// DeleteServiceAccount from cluster and cache
 func DeleteServiceAccount(key, paralusAuthzSA, paralusAuthzRole, paralusAuthzRoleBind string, delCache bool) {
 	svclogger.Debug(
 		"DeleteServiceAccount",

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -773,7 +773,7 @@ func cdRelayServerBootStrap(ctx context.Context, log *relaylogger.RelayLog) {
 	ticker.Stop()
 }
 
-//RunRelayServer entry to the relay server
+// RunRelayServer entry to the relay server
 func RunRelayServer(ctx context.Context, logLvl int) {
 	rctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -812,7 +812,7 @@ restartServer:
 	}
 }
 
-//RunCDRelayServer entry to the relay server
+// RunCDRelayServer entry to the relay server
 func RunCDRelayServer(ctx context.Context, logLvl int) {
 	rctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/relaylogger/relaylogger.go
+++ b/pkg/relaylogger/relaylogger.go
@@ -64,43 +64,43 @@ func (l *RelayLog) relaylog(level int, msg string, kvs ...interface{}) {
 
 }
 
-//Enabled log enabled
+// Enabled log enabled
 func (_ *RelayLog) Enabled() bool {
 	return true
 }
 
-//Critical log critical
+// Critical log critical
 func (l *RelayLog) Critical(msg string, kvs ...interface{}) {
 	l.relaylog(0, msg, kvs...)
 }
 
-//Error log error level
+// Error log error level
 func (l *RelayLog) Error(err error, msg string, kvs ...interface{}) {
 	kvs = append(kvs, "error", err)
 	l.relaylog(1, msg, kvs...)
 }
 
-//Warn log warning level
+// Warn log warning level
 func (l *RelayLog) Warn(msg string, kvs ...interface{}) {
 	l.relaylog(2, msg, kvs...)
 }
 
-//Info log info level
+// Info log info level
 func (l *RelayLog) Info(msg string, kvs ...interface{}) {
 	l.relaylog(3, msg, kvs...)
 }
 
-//Debug log debug level
+// Debug log debug level
 func (l *RelayLog) Debug(msg string, kvs ...interface{}) {
 	l.relaylog(4, msg, kvs...)
 }
 
-//V ..
+// V ..
 func (l *RelayLog) V(_ int) *RelayLog {
 	return l
 }
 
-//WithName set log name
+// WithName set log name
 func (l *RelayLog) WithName(name string) *RelayLog {
 	var objName string
 	if l.name == "" {
@@ -116,7 +116,7 @@ func (l *RelayLog) WithName(name string) *RelayLog {
 	}
 }
 
-//WithValues log  key values
+// WithValues log  key values
 func (l *RelayLog) WithValues(kvs ...interface{}) *RelayLog {
 	newMap := make(map[string]interface{}, len(l.keyValues)+len(kvs)/2)
 	for k, v := range l.keyValues {
@@ -132,7 +132,7 @@ func (l *RelayLog) WithValues(kvs ...interface{}) *RelayLog {
 	}
 }
 
-//NewLogger create new logger
+// NewLogger create new logger
 func NewLogger(level int) *RelayLog {
 	if runLevel < level {
 		runLevel = level
@@ -140,7 +140,7 @@ func NewLogger(level int) *RelayLog {
 	return &RelayLog{level: level}
 }
 
-//SetRunTimeLogLevel set a run time log level
+// SetRunTimeLogLevel set a run time log level
 func SetRunTimeLogLevel(level int) {
 	fmt.Println("log level changed from ", runLevel, " to ", level)
 	runLevel = level

--- a/pkg/sessions/usersession.go
+++ b/pkg/sessions/usersession.go
@@ -11,7 +11,7 @@ import (
 	"github.com/twmb/murmur3"
 )
 
-//UserSession session cache
+// UserSession session cache
 type UserSession struct {
 	// Type of the server. Relay means user-facing
 	// Dialin means cluster-facing
@@ -70,7 +70,7 @@ var (
 
 var _dummyHandler = func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {}
 
-//InitUserSessionCache init user cache
+// InitUserSessionCache init user cache
 func InitUserSessionCache() error {
 	var err error
 	userSessions, err = ristretto.NewCache(&ristretto.Config{
@@ -105,7 +105,7 @@ func GetSecretRoleCheck(method, url string) bool {
 	return h != nil
 }
 
-//GetUserSession get the user session
+// GetUserSession get the user session
 func GetUserSession(skey string) (*UserSession, bool) {
 	hkey := getUserCacheKey(skey)
 	if val, ok := userSessions.Get(hkey); ok {
@@ -114,19 +114,19 @@ func GetUserSession(skey string) (*UserSession, bool) {
 	return nil, false
 }
 
-//AddUserSession add user session
+// AddUserSession add user session
 func AddUserSession(s *UserSession, skey string) {
 	hkey := getUserCacheKey(skey)
 	userSessions.SetWithTTL(hkey, s, 100, time.Minute*15)
 }
 
-//DeleteUserSession add user session
+// DeleteUserSession add user session
 func DeleteUserSession(skey string) {
 	hkey := getUserCacheKey(skey)
 	userSessions.Del(hkey)
 }
 
-//UpdateUserSessionExpiry set a short TTL when error happens
+// UpdateUserSessionExpiry set a short TTL when error happens
 func UpdateUserSessionExpiry(skey string, secs int) {
 	hkey := getUserCacheKey(skey)
 	if val, ok := userSessions.Get(hkey); ok {
@@ -139,7 +139,7 @@ func UpdateUserSessionExpiry(skey string, secs int) {
 	}
 }
 
-//SetSessionErrorFlag ser session errflg
+// SetSessionErrorFlag ser session errflg
 func SetSessionErrorFlag(skey string) {
 	hkey := getUserCacheKey(skey)
 	if val, ok := userSessions.Get(hkey); ok {
@@ -150,7 +150,7 @@ func SetSessionErrorFlag(skey string) {
 	}
 }
 
-//getUserCacheKey get cache key
+// getUserCacheKey get cache key
 func getUserCacheKey(skey string) (key uint64) {
 	hasher := _hashPool.Get().(hash.Hash64)
 	hasher.Reset()

--- a/pkg/tunnel/client.go
+++ b/pkg/tunnel/client.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-//ClientConfig ..
+// ClientConfig ..
 type ClientConfig struct {
 	//ServiceName name of the service
 	ServiceName string
@@ -42,7 +42,7 @@ type ClientConfig struct {
 	Logger *relaylogger.RelayLog
 }
 
-//Client struct
+// Client struct
 type Client struct {
 	sync.Mutex
 	conn               net.Conn
@@ -75,7 +75,7 @@ func expBackoff(c BackoffConfig) *backoff.ExponentialBackOff {
 	return b
 }
 
-//loadNewRelayNetwork start the relay agent for a given network
+// loadNewRelayNetwork start the relay agent for a given network
 func loadNewRelayNetwork(ctx context.Context, rnc utils.RelayNetworkConfig) error {
 	var spxy proxy.Func
 	var tlsconf *tls.Config
@@ -235,7 +235,7 @@ func (c *Client) runClient(ctx context.Context) {
 	}
 }
 
-//Start relay client
+// Start relay client
 func (c *Client) Start(ctx context.Context) error {
 	cw := make(chan bool)
 
@@ -356,7 +356,7 @@ func (c *Client) processDialoutProxy(conn net.Conn, network, addr string) error 
 	return nil
 }
 
-//dialout connect
+// dialout connect
 func (c *Client) connect() (net.Conn, error) {
 	c.Lock()
 	defer c.Unlock()
@@ -374,7 +374,7 @@ func (c *Client) connect() (net.Conn, error) {
 	return conn, nil
 }
 
-//dial
+// dial
 func (c *Client) dial() (net.Conn, error) {
 	var (
 		network   = "tcp"
@@ -582,7 +582,7 @@ func (c *Client) handleHandshake(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
-//setups the proxy func handler
+// setups the proxy func handler
 func clientProxy(svcName string, d *Dialout, logger *relaylogger.RelayLog) proxy.Func {
 	proxyCfg := &utils.ProxyConfig{
 		Protocol:           d.Protocol,
@@ -628,7 +628,7 @@ func clientProxy(svcName string, d *Dialout, logger *relaylogger.RelayLog) proxy
 	}
 }
 
-//StartClient starts relay clients
+// StartClient starts relay clients
 func StartClient(ctx context.Context, log *relaylogger.RelayLog, file string, rnc utils.RelayNetworkConfig, exitChan chan<- bool) {
 	clog = log.WithName("Client")
 

--- a/pkg/tunnel/common.go
+++ b/pkg/tunnel/common.go
@@ -24,7 +24,7 @@ var (
 	emptyID         [32]byte
 )
 
-//ServerTLSConfigFromBytes prepare a tls config from cert,key,rootCA
+// ServerTLSConfigFromBytes prepare a tls config from cert,key,rootCA
 func ServerTLSConfigFromBytes(certList []utils.SNICertificate, rootCAs []string, nextprotos ...string) (*tls.Config, error) {
 	var err error
 
@@ -76,7 +76,7 @@ func ServerTLSConfigFromBytes(certList []utils.SNICertificate, rootCAs []string,
 	return config, nil
 }
 
-//ClientTLSConfigFromBytes sets tls config
+// ClientTLSConfigFromBytes sets tls config
 func ClientTLSConfigFromBytes(tlsCrt []byte, tlsKey []byte, rootPEM []byte, addr string) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair(tlsCrt, tlsKey)
 	if err != nil {
@@ -110,7 +110,7 @@ func ClientTLSConfigFromBytes(tlsCrt []byte, tlsKey []byte, rootPEM []byte, addr
 	}, nil
 }
 
-//ClientTLSConfig sets tls config
+// ClientTLSConfig sets tls config
 func ClientTLSConfig(tlsCrt string, tlsKey string, rootCA string, addr string) (*tls.Config, error) {
 
 	cert, err := tls.LoadX509KeyPair(tlsCrt, tlsKey)
@@ -149,7 +149,7 @@ func ClientTLSConfig(tlsCrt string, tlsKey string, rootCA string, addr string) (
 	}, nil
 }
 
-//GetRemoteCertID extract peer ID
+// GetRemoteCertID extract peer ID
 func GetRemoteCertID(conn *tls.Conn) (string, error) {
 	// Try a TLS connection over the given connection. We explicitly perform
 	// the handshake, since we want to maintain the invariant that, if this

--- a/pkg/tunnel/dialin_pool.go
+++ b/pkg/tunnel/dialin_pool.go
@@ -50,7 +50,7 @@ func (p *dialinPool) URL(key string) string {
 	return fmt.Sprint("https://", key)
 }
 
-//GetClientConn get connector
+// GetClientConn get connector
 func (p *dialinPool) GetClientConn(req *http.Request, addr string) (*http2.ClientConn, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -156,7 +156,7 @@ func (p *dialinPool) AddConn(conn net.Conn, identifier string, sni string, remot
 	return key, nil
 }
 
-//GetDialinConnectorKey get connector key
+// GetDialinConnectorKey get connector key
 func (p *dialinPool) GetDialinConnectorCount(sni string) (int, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -189,7 +189,7 @@ func (p *dialinPool) getConnKey(sni string, item *dialinConnector, count int) (s
 	return "", fmt.Errorf("Empty dialin pool.dialinConnectors for sni %s ", sni)
 }
 
-//GetDialinConnectorKey get connector key
+// GetDialinConnectorKey get connector key
 func (p *dialinPool) GetDialinConnectorKey(sni string) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -335,7 +335,7 @@ func (p *dialinPool) addr(identifier string) string {
 	return identifier
 }
 
-//StartDialinPoolMgr starting dialin connection manager
+// StartDialinPoolMgr starting dialin connection manager
 func StartDialinPoolMgr(ctx context.Context, log *relaylogger.RelayLog, exitChan chan<- bool) {
 	_dplog = log.WithName("DialinPool")
 
@@ -351,7 +351,7 @@ func StartDialinPoolMgr(ctx context.Context, log *relaylogger.RelayLog, exitChan
 	}
 }
 
-//GetDialinMetrics get connector key
+// GetDialinMetrics get connector key
 func (p *dialinPool) GetDialinMetrics(w http.ResponseWriter) {
 	var clusterCnt, connCnt int
 	clusterCnt, connCnt = 0, 0

--- a/pkg/tunnel/peer.go
+++ b/pkg/tunnel/peer.go
@@ -17,7 +17,7 @@ import (
 
 var peerlog *relaylogger.RelayLog
 
-//StartPeeringMgr will start the peering RPCs
+// StartPeeringMgr will start the peering RPCs
 func StartPeeringMgr(ctx context.Context, log *relaylogger.RelayLog, exitChan chan<- bool, config *ServerConfig) {
 	var tlsConfig *tls.Config
 	var err error

--- a/pkg/tunnel/server.go
+++ b/pkg/tunnel/server.go
@@ -72,7 +72,7 @@ type Server struct {
 	auditPath string
 }
 
-//RelayConn connection info
+// RelayConn connection info
 type RelayConn struct {
 	// Conn is the network connection
 	Conn net.Conn
@@ -97,7 +97,7 @@ type RelayConn struct {
 	dialinCachedKey string
 }
 
-//ServerListen defines a listen object
+// ServerListen defines a listen object
 type ServerListen struct {
 	// Addr specifies the listen address
 	Addr string
@@ -342,7 +342,7 @@ func (srv *Server) connectRequest(key string, msg *utils.ControlMessage, r io.Re
 	return req, nil
 }
 
-//dialinLookup check for cluster connection
+// dialinLookup check for cluster connection
 func dialinCountLookup(sni string) int {
 	for _, dsrv := range Servers {
 		if dsrv.Type == utils.DIALIN {
@@ -356,7 +356,7 @@ func dialinCountLookup(sni string) int {
 	return 0
 }
 
-//ProcessPeerForwards ...
+// ProcessPeerForwards ...
 func (srv *Server) ProcessPeerForwards(w http.ResponseWriter, r *http.Request, lg *relaylogger.RelayLog, relayIP string, certIssue int64) {
 
 	lg.Debug("ProcessPeerForwards:", relayIP, r.TLS.ServerName)
@@ -452,7 +452,7 @@ processCDPeerForwardDone:
 	return
 }
 
-//ProcessRelayRequest process user-facing request
+// ProcessRelayRequest process user-facing request
 func (srv *Server) ProcessRelayRequest(w http.ResponseWriter, r *http.Request, lg *relaylogger.RelayLog) {
 	var (
 		paralusUserName   string
@@ -828,7 +828,7 @@ func jsonError(w http.ResponseWriter, message, reason string, code int) {
 	fmt.Fprintln(w, message+" "+reason)
 }
 
-//ServeHTTP requests from userfacing connection
+// ServeHTTP requests from userfacing connection
 func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	servelog := slog.WithName("RelayServeHTTP")
 	servelog.Debug(
@@ -869,7 +869,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 }
 
-//AddToDialinPool add connection to dialin pool of the server
+// AddToDialinPool add connection to dialin pool of the server
 func (srv *Server) AddToDialinPool(rconn *RelayConn, remoteAddr string) (string, error) {
 	slog.Info(
 		"AddToDialinPool",
@@ -912,9 +912,9 @@ func getSNIMuxDebugString(tmp []byte) string {
 	return dstr
 }
 
-//StartHTTPSListen start TLS listen on address
-//Both user & dialin endpoint listen on 443
-//Based on SNI traffic is routed/muxed to appropriate handler
+// StartHTTPSListen start TLS listen on address
+// Both user & dialin endpoint listen on 443
+// Based on SNI traffic is routed/muxed to appropriate handler
 func (sl *ServerListen) StartHTTPSListen(ctx context.Context) {
 	slistenlog := slog.WithName("Listener")
 	slistenlog.Info(
@@ -1233,8 +1233,8 @@ proxyCDDilainConnectionDone:
 	time.Sleep(2 * time.Second)
 }
 
-//start the unix socket that listens for connections to
-//stich to a dialin. User request are handled here
+// start the unix socket that listens for connections to
+// stich to a dialin. User request are handled here
 func (srv *Server) startUnixListen(ctx context.Context, lg *relaylogger.RelayLog) {
 	//start listen the dialin unix pipe
 	socketpath := utils.UNIXSOCKET + srv.ServerName
@@ -1291,7 +1291,7 @@ func (srv *Server) startUnixListen(ctx context.Context, lg *relaylogger.RelayLog
 	}
 }
 
-//sni based muxing (virtual hosting) handler that get called based on SNI
+// sni based muxing (virtual hosting) handler that get called based on SNI
 func (srv *Server) sniListen(ctx context.Context, sni string, l net.Listener, sl *ServerListen) {
 	var tlsconfig *tls.Config
 	var err error
@@ -2039,7 +2039,7 @@ func deleteConnections(key string) {
 	delete(connections, key)
 }
 
-//DialinMetric for cluster connection
+// DialinMetric for cluster connection
 func DialinMetric(w http.ResponseWriter) {
 	for _, dsrv := range Servers {
 		if dsrv.Type == utils.DIALIN {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -46,13 +46,13 @@ const (
 	CDAGENTCORE      = "paralus-core-cd-relay-agent"
 )
 
-//SNICertificate sni based certs
+// SNICertificate sni based certs
 type SNICertificate struct {
 	CertFile []byte
 	KeyFile  []byte
 }
 
-//Relaynetwork configmap data
+// Relaynetwork configmap data
 type Relaynetwork struct {
 	Token         string `json:"token"`         // bootstrap agent token
 	Addr          string `json:"addr"`          // bootstrap register host
@@ -62,7 +62,7 @@ type Relaynetwork struct {
 	Upstream      string `json:"upstream"`      // upstream tcp service host:port
 }
 
-//RelayNetworkConfig config for relay agent
+// RelayNetworkConfig config for relay agent
 type RelayNetworkConfig struct {
 	// Network configmap
 	Network Relaynetwork
@@ -286,7 +286,7 @@ var (
 	HealingInterval = 24 // Hour
 )
 
-//CountWriter to measure bytes
+// CountWriter to measure bytes
 type CountWriter struct {
 	W     io.Writer
 	Count int64
@@ -324,7 +324,7 @@ type ProxyConfig struct {
 	Version            string
 }
 
-//ProxyProtocolMessage used across dialin unix socket
+// ProxyProtocolMessage used across dialin unix socket
 type ProxyProtocolMessage struct {
 	DialinKey string
 	UserName  string
@@ -339,17 +339,17 @@ type ServiceAccountCacheObject struct {
 	Key                  string
 }
 
-//OnEvict cache on eviction call back function
+// OnEvict cache on eviction call back function
 type OnEvict = func(item *ristretto.Item)
 
-//Fatal to exit the program
+// Fatal to exit the program
 func Fatal(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, a...)
 	fmt.Fprint(os.Stderr, "\n")
 	os.Exit(1)
 }
 
-//CloneHeader clone http headers
+// CloneHeader clone http headers
 func CloneHeader(h http.Header) http.Header {
 	h2 := make(http.Header, len(h))
 	for k, vv := range h {
@@ -360,7 +360,7 @@ func CloneHeader(h http.Header) http.Header {
 	return h2
 }
 
-//SetXForwardedFor ...
+// SetXForwardedFor ...
 func SetXForwardedFor(h http.Header, remoteAddr string) {
 	clientIP, _, err := net.SplitHostPort(remoteAddr)
 	if err == nil {
@@ -374,7 +374,7 @@ func SetXForwardedFor(h http.Header, remoteAddr string) {
 	}
 }
 
-//SetXRAYUUID ...
+// SetXRAYUUID ...
 func SetXRAYUUID(h http.Header) {
 	var reluuid string
 
@@ -388,7 +388,7 @@ func SetXRAYUUID(h http.Header) {
 	h.Set("X-Paralus-XRAY-RELAYUUID", reluuid)
 }
 
-//SetXForwardedParalus set paralus headers
+// SetXForwardedParalus set paralus headers
 func SetXForwardedParalus(h http.Header, msg *ControlMessage) {
 	h.Set("X-Paralus-User", msg.ParalusUserName)
 	h.Set("X-Paralus-Namespace", msg.ParalusNamespace)
@@ -396,7 +396,7 @@ func SetXForwardedParalus(h http.Header, msg *ControlMessage) {
 	h.Set("X-Paralus-Allow", msg.ParalusAllow)
 }
 
-//UnSetXForwardedParalus set paralus headers
+// UnSetXForwardedParalus set paralus headers
 func UnSetXForwardedParalus(h http.Header) {
 	h.Del("X-Paralus-Scope")
 	h.Del("X-Paralus-Allow")
@@ -411,7 +411,7 @@ func UnSetXForwardedParalus(h http.Header) {
 	h.Del("X-Paralus-User-Cert-Issued")
 }
 
-//Transfer transfer by io.Copy
+// Transfer transfer by io.Copy
 func Transfer(dst io.Writer, src io.Reader, tlog *relaylogger.RelayLog, direction string) {
 	n, err := io.Copy(dst, src)
 	if err != nil {
@@ -448,7 +448,7 @@ func (cw *CountWriter) Write(p []byte) (n int, err error) {
 	return
 }
 
-//CopyHeader copy header
+// CopyHeader copy header
 func CopyHeader(dst, src http.Header) {
 	for k, v := range src {
 		vv := make([]string, len(v))
@@ -489,7 +489,7 @@ func ReadControlMessage(r *http.Request) (*ControlMessage, error) {
 	return &msg, nil
 }
 
-//FlushWriter flush writer
+// FlushWriter flush writer
 type FlushWriter struct {
 	W io.Writer
 }
@@ -502,18 +502,18 @@ func (fw FlushWriter) Write(p []byte) (n int, err error) {
 	return
 }
 
-//KeepAlive set keepalive
+// KeepAlive set keepalive
 func KeepAlive(conn net.Conn) error {
 	return tcpkeepalive.SetKeepAlive(conn, DefaultKeepAliveIdleTime, DefaultKeepAliveCount, DefaultKeepAliveInterval)
 }
 
-//GenUUID generates a google UUID
+// GenUUID generates a google UUID
 func GenUUID() {
 	id := uuid.New()
 	RelayUUID = id.String()
 }
 
-//GetRelayIP get relay IP address
+// GetRelayIP get relay IP address
 func GetRelayIP() string {
 	if RelayIPFromConfig == "" {
 		name, err := os.Hostname()
@@ -537,7 +537,7 @@ func GetRelayIPPort() string {
 	return RelayIPFromConfig
 }
 
-//CheckRelayLoops :does XRAY UUDI already present in header?
+// CheckRelayLoops :does XRAY UUDI already present in header?
 func CheckRelayLoops(h http.Header) bool {
 	if uuidHdr, ok := h["X-Paralus-XRAY-RELAYUUID"]; ok {
 		allIds := strings.Join(uuidHdr, ", ")
@@ -577,7 +577,7 @@ func DeleteCache(cache *ristretto.Cache, key interface{}) {
 	cache.Del(key)
 }
 
-//WriteFile overwrite if exist
+// WriteFile overwrite if exist
 func WriteFile(filename, data string) error {
 	file, err := os.Create(filename)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: mabhi <abhijit.mukherjee@infracloud.io>

### What does this PR change?

- This PR reads a new label introduced for SA named `authz-expiry` that is check  for staleness during regular cleanup sweeps and if it happens to be older than the current time during the sweep ticker, the SA and its dependent resources are cleaned up

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- [135](https://github.com/paralus/paralus/pull/135)
- Actual feature [98](https://github.com/paralus/paralus/issues/98)

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
