### PR TITLE
Feature: Updated cleanup logic w.r.t `authz-expiry` label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
+-  Configure the SA account lifetime from [mabhi](https://github.com/mabhi)
 
 ## [0.1.2] - 2022-09-30
 ### Added

--- a/pkg/cleanup/authz.go
+++ b/pkg/cleanup/authz.go
@@ -21,13 +21,12 @@ var (
 
 const (
 	// how often should the cleanup routine run
-	sweepInterval = time.Minute * 10
-	// any authz which is olderThan this should be cleaned up
-	olderThan = time.Hour * 8
+	sweepInterval = time.Minute * 5
 
 	paralusRelayLabel = "paralus-relay"
 	authzRefreshLabel = "authz-refreshed"
 	paralusSystemNS   = "paralus-system"
+	authzExpiryLabel  = "authz-expiry"
 
 	maxResults = 50
 )
@@ -42,9 +41,9 @@ func getMatchingLabelSelector() (sel client.MatchingLabelsSelector, err error) {
 	}
 
 	refreshLabelReq, err = labels.NewRequirement(
-		authzRefreshLabel,
+		authzExpiryLabel,
 		selection.LessThan,
-		[]string{strconv.FormatInt(time.Now().Add(-olderThan).Unix(), 10)},
+		[]string{strconv.FormatInt(time.Now().Unix(), 10)},
 	)
 	if err != nil {
 		_log.Infow("unable to create authz refresh requirment", "error", err)


### PR DESCRIPTION
Signed-off-by: mabhi <abhijit.mukherjee@infracloud.io>

### What does this PR change?

- Added new logic to compute expiration of service account. A new label introduced and populated by paralus. `authz-expiry` label is populated from dashboard as an organization level setting.
- Relay changes in addition to  [98](https://github.com/paralus/paralus/issues/98)

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- [139](https://github.com/paralus/paralus/pull/139)
- [158](https://github.com/paralus/dashboard/pull/158)

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
