### PR TITLE
Fix to terminate relay-agent on multiple bootstrap agent registration…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Fix to terminate relay-agent on multiple bootstrap agent registration requests from [niravparikh05](https://github.com/niravparikh05)
+
 ## [0.1.3] - 2023-02-24
 ### Added
 -  Configure the SA account lifetime from [mabhi](https://github.com/mabhi)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -355,6 +356,9 @@ func registerRelayAgent(ctx context.Context, rn utils.Relaynetwork) error {
 			err,
 			"failed to register relay agent",
 		)
+		if strings.Contains(err.Error(), "multiple agent register requests") {
+			utils.TerminateChan <- true
+		}
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR change?

- Fix to terminate relay-agent on multiple bootstrap agent registration requests

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- https://github.com/paralus/paralus/pull/171

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
