### PR TITLE
invoke updating cluster health based on the dialin connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/inconshreveable/go-vhost v0.0.0-20160627193104-06d84117953b
 	github.com/jinzhu/inflection v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/paralus/paralus v0.2.5-0.20230921060456-1b7a9a1fa32e
+	github.com/paralus/paralus v0.2.7-0.20240212135918-669e222441b2
 	github.com/rs/xid v1.3.0
 	github.com/segmentio/encoding v0.3.4
 	github.com/spf13/pflag v1.0.5
@@ -22,6 +22,7 @@ require (
 	golang.org/x/net v0.17.0
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/grpc v1.56.3
+	google.golang.org/protobuf v1.30.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
@@ -110,7 +111,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ory/kratos-client-go v0.11.0 h1:8FF2GiLjvDEPiN4fVLiHgnKZspQdd7kXDlBbeJJq+aw=
 github.com/ory/kratos-client-go v0.11.0/go.mod h1:8gqPMa6bB+NHbDurRY6D2dOTLrjYEdg/Dx+JvwXsZ0Q=
-github.com/paralus/paralus v0.2.5-0.20230921060456-1b7a9a1fa32e h1:4tXra34G/yMoBhznlumOAVtZX5KnD5jWPlJfOoXnb8g=
-github.com/paralus/paralus v0.2.5-0.20230921060456-1b7a9a1fa32e/go.mod h1:blseZik4e+Ddm6jhOlBiZVXAE5aaRNeI+qQ9r2a0s/Q=
+github.com/paralus/paralus v0.2.7-0.20240212135918-669e222441b2 h1:/pqUIwhrAMp6cr+oNx9hXOthoFEOlbShK8NhM1h/e+Q=
+github.com/paralus/paralus v0.2.7-0.20240212135918-669e222441b2/go.mod h1:utnT63Nd7EiYw3oc7NryvL6V3zhfVYSNWXZG4Hpwy8U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=

--- a/pkg/tunnel/healthz.go
+++ b/pkg/tunnel/healthz.go
@@ -17,16 +17,19 @@ func syncClusterHeath(sni string, status commonv3.ParalusConditionStatus, reason
 	id, err := getClusterID(sni)
 	if err != nil {
 		_log.Error("unable to get clusterID", "error", err)
+		return
 	}
 
 	u, err := url.Parse(utils.PeerServiceURI)
 	if err != nil {
 		_log.Error("unable to parse peer service url", "error", err)
+		return
 	}
 	//Load certificates
 	tlsConfig, err := ClientTLSConfigFromBytes(utils.PeerCertificate, utils.PeerPrivateKey, utils.PeerCACertificate, u.Host)
 	if err != nil {
 		_log.Error("unable to build tls config for peer service", "error", err)
+		return
 	}
 	transportCreds := credentials.NewTLS(tlsConfig)
 	peerSeviceHost := u.Host
@@ -35,6 +38,7 @@ func syncClusterHeath(sni string, status commonv3.ParalusConditionStatus, reason
 	conn, err := grpc.NewSecureClientConn(ctx, peerSeviceHost, transportCreds)
 	if err != nil {
 		_log.Error("unable to connect to core", "error", err)
+		return
 	}
 	defer conn.Close()
 
@@ -57,6 +61,7 @@ func syncClusterHeath(sni string, status commonv3.ParalusConditionStatus, reason
 	})
 	if err != nil {
 		_log.Error("failed to update cluster status", "error", err)
+		return
 	}
 	_log.Debug("successfully update cluster ", sni, " status ", status)
 }

--- a/pkg/tunnel/healthz.go
+++ b/pkg/tunnel/healthz.go
@@ -1,0 +1,62 @@
+package tunnel
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/paralus/paralus/pkg/grpc"
+	rpcv3 "github.com/paralus/paralus/proto/rpc/scheduler"
+	commonv3 "github.com/paralus/paralus/proto/types/commonpb/v3"
+	infrav3 "github.com/paralus/paralus/proto/types/infrapb/v3"
+	"github.com/paralus/relay/pkg/utils"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func syncClusterHeath(sni string, status commonv3.ParalusConditionStatus, reason string) {
+	id, err := getClusterID(sni)
+	if err != nil {
+		_log.Error("unable to get clusterID", "error", err)
+	}
+
+	u, err := url.Parse(utils.PeerServiceURI)
+	if err != nil {
+		_log.Error("unable to parse peer service url", "error", err)
+	}
+	//Load certificates
+	tlsConfig, err := ClientTLSConfigFromBytes(utils.PeerCertificate, utils.PeerPrivateKey, utils.PeerCACertificate, u.Host)
+	if err != nil {
+		_log.Error("unable to build tls config for peer service", "error", err)
+	}
+	transportCreds := credentials.NewTLS(tlsConfig)
+	peerSeviceHost := u.Host
+
+	ctx := context.Background()
+	conn, err := grpc.NewSecureClientConn(ctx, peerSeviceHost, transportCreds)
+	if err != nil {
+		_log.Error("unable to connect to core", "error", err)
+	}
+	defer conn.Close()
+
+	client := rpcv3.NewClusterServiceClient(conn)
+	_, err = client.UpdateClusterStatus(ctx, &rpcv3.UpdateClusterStatusRequest{
+		Metadata: &commonv3.Metadata{
+			Id:      id,
+			Project: id,
+		},
+		ClusterStatus: &infrav3.ClusterStatus{
+			Conditions: []*infrav3.ClusterCondition{
+				{
+					Type:        infrav3.ClusterConditionType_ClusterHealth,
+					Status:      status,
+					LastUpdated: timestamppb.Now(),
+					Reason:      reason,
+				},
+			},
+		},
+	})
+	if err != nil {
+		_log.Error("failed to update cluster status", "error", err)
+	}
+	_log.Debug("successfully update cluster ", sni, " status ", status)
+}


### PR DESCRIPTION
### What does this PR change?

- Enhancement for https://github.com/paralus/paralus/issues/245
- Added syncClusterHeath which creates a client connection with paralus core and invokes ClusterUpdateStatus
- Invokes syncClusterHeath in async whenever connection is established / disconnected from target agent.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- https://github.com/paralus/paralus/pull/296

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
