### PR TITLE
restricted the port-forwording for read-only user

### DIFF
--- a/pkg/sessions/usersession.go
+++ b/pkg/sessions/usersession.go
@@ -89,6 +89,9 @@ func InitUserSessionCache() error {
 	roleCheck.Handle("GET", "/api/:version/namespaces/:namespace/secrets/*name", _dummyHandler)
 	roleCheck.Handle("GET", "/api/:version/secrets/*name", _dummyHandler)
 
+	roleCheck.Handle("POST", "/api/:version/namespaces/:namespace/pods/:pod/portforward", _dummyHandler)
+	roleCheck.Handle("GET", "/api/:version/namespaces/:namespace/pods/:pod/portforward", _dummyHandler)
+
 	roleCheckSecret = httprouter.New()
 	roleCheckSecret.Handle("POST", "/api/:version/namespaces/:namespace/secrets", _dummyHandler)
 	roleCheckSecret.Handle("GET", "/api/:version/namespaces/:namespace/secrets", _dummyHandler)


### PR DESCRIPTION
### What does this PR change?

-  restricted the port-forwording for read-only user

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- paralus/paralus#201

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [x] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [x] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
